### PR TITLE
Faster deriver, termlink fix.

### DIFF
--- a/src/narjure/defaults.clj
+++ b/src/narjure/defaults.clj
@@ -55,10 +55,10 @@
 (def inverse-decay-rate 10)                                        ; forgetting adjustment rate for concepts e^-lt where l = (1.0 - durabiity) / decay-rate
 ; durability of 0.5 and decay rate of 100 fully decays priority in 1000 cycles
 ; decay-rate of 10 would fully decay it in 100 cycles
-(def system-tick-interval-slow 150)
-(def inference-tick-interval-slow 110)
-(def system-tick-interval-fast 50)
-(def inference-tick-interval-fast 25)
+(def system-tick-interval-slow 136)
+(def inference-tick-interval-slow 100)
+(def system-tick-interval-fast 40)
+(def inference-tick-interval-fast 20)
 (def system-tick-interval (atom system-tick-interval-slow))                               ;make big enough
 (def inference-tick-interval (atom inference-tick-interval-slow))
 (def anticipation-scale-dependent-tolerance 4.0)            ;has to be 4 since interval rounding has to agree with time measurement in 2-power

--- a/src/narjure/memory_management/termlink_utils.clj
+++ b/src/narjure/memory_management/termlink_utils.clj
@@ -71,7 +71,8 @@
 
 (defn update-termlink [tl]                                  ;term
   (let [old-strength ((:termlinks @state) tl)]
-    (add-termlink tl (calc-link-strength tl (if old-strength old-strength [0.5 0.0])))))
+    (add-termlink tl (calc-link-strength tl (if old-strength old-strength [0.5 0.0])))
+    (forget-termlinks)))
 
 (defn use-stronger [t1 t2]
   (let [all-keys (set/union (map first t1) (map first t2))]
@@ -115,7 +116,8 @@
           [f c] ((:termlinks @state) belief-concept-id)]
       (when (and f c (:truth derived-task)) ;just revise by using the truth value directly
         ;as evidence for the usefulness
-        (add-termlink belief-concept-id [1.0 truth-quality-to-confidence]))
+        (add-termlink belief-concept-id [1.0 truth-quality-to-confidence])
+        (forget-termlinks))
       )
     (catch Exception e () #_(println "fail"))))
 


### PR DESCRIPTION
First pull request since 2.0.0 release for AGI-16.

Including: Speedup for deriver, and a usually unproblematic termlink fix.