### PR TITLE
Clojure Libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pom.xml.asc
 \#*\#
 .\#*
 /src/nal/experiments.clj
+*.pyc
+*.log

--- a/src/examples/math.clj
+++ b/src/examples/math.clj
@@ -1,0 +1,39 @@
+(ns examples.math
+  (:require [narjure.sensorimotor :refer [nars-register-operation]]))
+
+; --- Support functions ---
+(defn apply_args
+    "Like apply but assumes the last item is a list,
+     the first item is the operation, and the rest are constant.
+     Ex: (apply * (into [1 2] args)) --> (apply_args * 1 2 args)"
+    [op & args]
+    (apply op (into (butlast x) (last x))))
+
+(defn map-hash-list [op x]
+  "Applies op to every item in the map of lists x.
+   op is a function taking only the value as a parameter."
+  (into {} (map (fn [[k v]] [k (map op v)]) (seq x))))
+(defn map-hash-list2 [op x]
+  "Applies op to every item in the map of lists x.
+   op is a function taking the key and value as a parameter."
+  (into {} (map (fn [[k v]] [k (map #(op k %) v)]) (seq x))))
+
+(defn template
+    "The template to register an op with NARS"
+    [op]
+    (fn [args operationgoal]
+      (try (apply_args op args)
+      (catch Exception e [false]))))
+
+; List the ops we desire by their library
+(def ops (seq {"math" ['+ '- '* '/ 'quot 'rem 'float 'double 'int]}))
+
+; Get their names by appending their op name to the library name 
+(def names (map-hash-list2 (fn [lib op] (str lib "_" op)) ops))
+
+; zip the ops and their names
+(def op-names (for [x (keys ops)] [(get ops x) (get names x)]))
+
+; register all operations
+(defn register []
+  (for [[op n] op-names] (nars-register-operation n (template op))))

--- a/src/examples/math.clj
+++ b/src/examples/math.clj
@@ -1,5 +1,10 @@
 (ns examples.math
-  (:require [narjure.sensorimotor :refer [nars-register-operation]]))
+  (:require [narjure.global-atoms :refer :all]
+            [narjure.core :as nar]
+            [narjure.narsese :refer [parse2]]
+            [narjure.sensorimotor :refer :all]
+            [narjure.debug-util :refer :all]
+            [narjure.string :as n]))
 
 ; --- Support functions ---
 (defn apply_args
@@ -7,7 +12,7 @@
      the first item is the operation, and the rest are constant.
      Ex: (apply * (into [1 2] args)) --> (apply_args * 1 2 args)"
     [op & args]
-    (apply op (into (butlast x) (last x))))
+    (apply op (into (butlast args) (last args))))
 
 (defn map-hash-list [op x]
   "Applies op to every item in the map of lists x.
@@ -22,39 +27,52 @@
     "The template to register an op with NARS"
     [op]
     (fn [args operationgoal]
-      (try (apply_args op args)
-      (catch Exception e [false]))))
-
-; List the ops we desire by their library
-(def ops {"core" [count type] "math" ['+ '- '* '/ 'quot 'rem 'float 'double 'int]})
-
-; Get their names by appending their op name to the library name 
-(def names (map-hash-list2 (fn [lib op] (str lib "_" op)) ops))
-
-; zip the ops and their names
-(def op-names (for [x (keys ops)] [(get ops x) (get names x)]))
-
-; register all operations
-(defn register []
-  (for [[op n] op-names]
-       (nars-register-operation n (template op))
-       (apply nars-input-narsese (requirements op))
-       ))
-
-(defn quotes [s] (str "\"" s "\""))
+      (apply_args op args)))
+      ;(catch Exception e [false]))))
 
 ; TODO pass values natively as objects
 (defn process-map1 [map_name m]
-  (map (fn [[k v]] (nsentence (n<-> (n* map_name k) v)) (seq m)))
+  (for [[k v] (seq m)] (n/belief (n/<-> (n/* map_name k) v))))
 (defn process-map2 [map_name m]
-  (map (fn [[k v]] (nsentence (n--> (n* map_name v) k)) (seq m)))
-(defn process-map3 [parent m]
-  (apply concat ; flattens the recursion
-  (for [k (keys m)]
-    (let [v (get m k)]
-      (if (map? v)
-        (recur (n* parent k) v)
-        [(nsentence (n<-> (n* parent k) v))])))))
+  (for [[k v] (seq m)] (n/belief (n/--> (n/* map_name v) k))))
+(defn rmap1 [k v]
+  (println k v)
+  (flatten
+  (if-not (map? v)
+    [(n/belief (n/<-> k (n/quotes v)))]
+    (when-not (empty? (seq v))
+      (map (fn [[a b]] (rmap1 (n/* k (n/quotes a)) b)) (seq v))))))
+(defn rmap2 [parent k v]
+  (println k v)
+  (flatten
+  (if-not (map? v)
+    [(n/belief (n/--> (n/* parent (n/quotes v)) k))]
+    (when-not (empty? (seq v))
+      (map (fn [[a b]] (rmap2 (n/* parent k) (n/quotes a) b)) (seq v))))))
 
-(defn requirements [op_name op]
-  (process-map1 op_name (meta #op)))
+; List the ops we desire by their library
+;(defmacro qt_lst [& x] (let [out (map #(list 'quote %) x)] (into [] out)))
+(defmacro meta_fun [fun] (list 'meta (list 'var fun)))
+(defmacro var_lst [& x] (let [out (map #(list 'var %) x)] (into [] out)))
+ ; for example
+
+
+; register all operations
+(defn requirements [fvar]
+  (rmap1 (n/quotes fvar) (meta fvar)))
+(defn register [fvar]
+  (nars-register-operation
+      (symbol (str fvar))
+      (template fvar))
+  (for [x (requirements fvar)] (do
+      (println (str "Sending " x))
+      (nars-input-narsese x))))
+
+(def ops (var_lst + - * / quot rem float double int))
+(defn -main [& args]
+  (nars-register-answer-handler (fn [task solution]
+                                  (let [msg (str "NARS answer on " (narsese-print (:statement task)) "? is " (task-to-narsese solution))]
+                                    (println msg))))
+  (for [x ops] (do (println "Registering " x) (register x)))
+  (nars-input-narsese "<(^\"#'clojure.core/+\",1,2) --> ?>?")
+  (nars-input-narsese "(^\"#'clojure.core/+\",1,2)?"))

--- a/src/narjure/string.clj
+++ b/src/narjure/string.clj
@@ -1,0 +1,64 @@
+(ns narjure.string
+    (:require [narjure.narsese :refer [copulas compound-terms actions]]))
+
+; General
+(defn quotes [s] (str "\"" s "\""))
+
+; Define sentences
+(defn belief [stmnt] (str stmnt "."))
+(defn question [stmnt] (str stmnt "?"))
+(defn quest [stmnt] (str stmnt "@"))
+(defn goal [stmnt] (str stmnt "!"))
+(def sentence belief)
+
+; Define Time
+(defn present [sent] (str sent " :|:"))
+(defn future [sent] (str sent " :|:"))
+(defn past [sent] (str sent " :|:"))
+(defn deftime [sent t] (str sent " :"t":"))
+(def now present)
+
+; Define Ops
+(defmacro defineop
+    ([o]
+    `(defn ~o [a# b#] (str "<" a# ~o b# ">")))
+    ([o s]
+    `(defn ~o [a# b#] (str "<" a# (str ~s) b# ">"))))
+
+; TODO: Find some way to do this with mapping onto copulas
+; (for [[k# v#] (into [] (seq copulas))] (do (println k# v#) (eval (list 'defineop v#))))
+; CompilerException java.lang.RuntimeException: Can't refer to qualified var that doesn't exist, compiling:(/tmp/form-init3886415578392221818.clj:1:7459)
+(defineop --> "-->")
+(defineop <-> "<->")
+(defineop instance "{--")
+(defineop property "--]")
+(defineop instance-property "{-]")
+(defineop ==> "==>")
+(defineop pred-impl "=/>")
+(defineop =|> "=|>")
+(defineop retro-impl "=\\>")
+(defineop <=> "<=>")
+(defineop pred-eq "</>")
+(defineop <|> "<|>")
+
+; Define Combinations
+(defmacro definecomp
+    ([o]
+    `(defn ~o [& a#] (str "(" ~o ", " (clojure.string/join ", " a#) ")")))
+    ([o s]
+    `(defn ~o [& a#] (str "(" (str ~s) ", " (clojure.string/join ", " a#) ")"))))
+
+(definecomp ext-set "{")
+(definecomp int-set "[")
+(definecomp ext-inter "&")
+(definecomp | "|")
+(definecomp - "-")
+(definecomp int-dif "~")
+(definecomp * "*")
+(definecomp ext-image "/")
+(definecomp int-image "\\")
+(definecomp -- "--")
+(definecomp || "||")
+(definecomp conj "&&")
+(definecomp seq-conj "&/")
+(definecomp &| "&|")


### PR DESCRIPTION
So, this started out as an example of adding math libraries to NARS. Now I'm doing something a little more ambitious. First, and as it stands now, it should be able to register any clojure library that uses strings as args and returns. Next, strings, numbers, lists (of the same), and bools. Lastly, any clojure object.

On registration, it also sends to narsese all the metadata of the function. In order to do this, part of the project is a full hash-map import. There are a few paradigms I'm tinkering with so they are split into rmap1 and rmap2.

The string.clj file is just something I've been needing, I don't quite understand the macros you all have set up for rules.clj etc and just want a non-string way of entering in data.

In the end, I'm wondering if this file couldn't put clojure objects directly into the statement field of an element map, and have that work. If not, we can name each argument somewhere in the pipeline and save them to a global atom.

Currently this builds, but it stalls on input, and I'm not at all sure why.
